### PR TITLE
Fixed stuffed belly sprite for non-round belly

### DIFF
--- a/GainStation13/code/modules/mob/living/belly.dm
+++ b/GainStation13/code/modules/mob/living/belly.dm
@@ -40,12 +40,13 @@
 	switch(owner.fullness)
 		if(FULLNESS_LEVEL_BLOATED to FULLNESS_LEVEL_BEEG)
 			icon = 'hyperstation/icons/obj/genitals/belly_round.dmi' //We use round belly to represent stuffedness
+			icon_state = "belly_round_[size]"
 		if(FULLNESS_LEVEL_BEEG to FULLNESS_LEVEL_NOMOREPLZ)
 			icon = 'hyperstation/icons/obj/genitals/belly_round.dmi'
-			icon_state = "belly_[icon_shape_state]_[size+1]"
+			icon_state = "belly_round_[size+1]"
 		if(FULLNESS_LEVEL_NOMOREPLZ to INFINITY)
 			icon = 'hyperstation/icons/obj/genitals/belly_round.dmi'
-			icon_state = "belly_[icon_shape_state]_[size+2]"
+			icon_state = "belly_round_[size+2]"
 
 	if(owner)
 		if(owner.dna.species.use_skintones && owner.dna.features["genitals_use_skintone"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixed an issue I missed when adding the alternate belly sprites. It caused the stuffed sprites to break and no longer show a belly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixing a bug I introduced
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Belly stuffed sprite breaking when not using a round belly shape.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
